### PR TITLE
Adjust codeUrl & website to point at GitHub page

### DIFF
--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -44,8 +44,8 @@ const pkgdef :Spk.PackageDefinition = (
         market = (svg = embed "resources/brainstorm-150.svg")
       ),
 
-      website = "https://github.com/Azeirah/brainstorm.git",
-      codeUrl = "https://github.com/Azeirah/brainstorm.git",
+      website = "https://github.com/Azeirah/brainstorm",
+      codeUrl = "https://github.com/Azeirah/brainstorm",
       license = (openSource = gpl2),
       categories = [productivity],
 


### PR DESCRIPTION
This commit adjusts the `website` and `codeUrl` links to point at the GitHub page for the project, avoiding redirects.

This has the upside that if we start to do URL concatenation to point people directly at your issue tracker, they will successfully get there.

Specifically, this is a link gets response code 200 from GitHub: https://github.com/Azeirah/brainstorm/issues

but this one gets status code 404: https://github.com/Azeirah/brainstorm.git/issues
