### PR TITLE
Fix broken link on github rendered readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Todo features
 
 1. Widgets
 2. Accounts
-3. Privacy, so that nobody can remove or edit your notes without your permission, which is **totally not happening all the time at the [demo](brainstorm-notes.meteor.com)**
+3. Privacy, so that nobody can remove or edit your notes without your permission, which is **totally not happening all the time at the [demo](https://brainstorm-notes.meteor.com)**
 
 Goal
 ---


### PR DESCRIPTION
Previously rendered link: https://github.com/Azeirah/brainstorm/blob/master/brainstorm-notes.meteor.com
New one: https://brainstorm-notes.meteor.com