### PR TITLE
Make demo link point to Sandstorm demo service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Brainstorm
 
 Brainstorm is a note-taking application made with love and my childhood dreams.
 
-## [Demo](http://brainstorm-notes.meteor.com)
+## [Demo](https://demo.sandstorm.io/appdemo/sptx6z162fp1w8rwe92vc8tzm76v0mk0wwc9yafze2vpghjs48j0)
 
-[![Demo](https://raw.githubusercontent.com/Azeirah/brainstorm/master/Brainstorm-preview.png)](http://brainstorm-notes.meteor.com)
+[![Demo](https://raw.githubusercontent.com/Azeirah/brainstorm/master/Brainstorm-preview.png)](https://demo.sandstorm.io/appdemo/sptx6z162fp1w8rwe92vc8tzm76v0mk0wwc9yafze2vpghjs48j0)
 
 Features
 ---


### PR DESCRIPTION
Hi @Azeirah !

I noticed that the Meteor demo was giving a 404, so I figure using the Sandstorm demo service is an improvement.

https://sandstorm.io/news/2015-02-06-app-demo provides some information on the special "appdemo" link I'm using here.

It caught my attention due to discussion of Brainstorm on Twitter due to @ScottWNesbitt 's article mentioning Brainstorm on opensource.com: https://opensource.com/life/16/8/open-source-alternatives-evernote